### PR TITLE
Automatic slot lifecycle handling via observer inheritance.

### DIFF
--- a/include/sigslot/signal.hpp
+++ b/include/sigslot/signal.hpp
@@ -717,7 +717,14 @@ private:
     std::vector<scoped_connection> m_connections;
 };
 
+/**
+ * Specialization of observer_base to be used in single threaded contexts.
+ */
 using observer_st = observer_base<detail::null_mutex>;
+
+/**
+ * Specialization of observer_base to be used in multi-threaded contexts.
+ */
 using observer = observer_base<std::mutex>;
 
 namespace detail {
@@ -1241,7 +1248,8 @@ public:
     template <typename Pmf, typename Ptr>
     std::enable_if_t<
     trait::is_callable_v<arg_list, Pmf, Ptr> &&
-    !trait::is_observer_v<Lockable, std::remove_pointer_t<Ptr>> &&
+    !trait::is_observer_v<std::mutex, std::remove_pointer_t<Ptr>> &&
+    !trait::is_observer_v<detail::null_mutex, std::remove_pointer_t<Ptr>> &&
     !trait::is_weak_ptr_compatible_v<Ptr>, connection>
     connect(Pmf && pmf, Ptr && ptr, group_id gid = 0) {
         using slot_t = detail::slot_pmf<Pmf, Ptr, T...>;

--- a/include/sigslot/signal.hpp
+++ b/include/sigslot/signal.hpp
@@ -20,8 +20,12 @@
 
 namespace sigslot {
 
-template <typename Lockable>
-struct observer_base;
+namespace detail {
+
+// Used to detect an object of observer type
+struct observer_type {};
+
+} // namespace detail
 
 namespace trait {
 
@@ -123,8 +127,9 @@ constexpr bool is_func_v = std::is_function<T>::value;
 template <typename T>
 constexpr bool is_pmf_v = std::is_member_function_pointer<T>::value;
 
-template <typename Lockable, typename T>
-constexpr bool is_observer_v = std::is_base_of<::sigslot::observer_base<Lockable>, T>::value;
+template <typename T>
+constexpr bool is_observer_v = std::is_base_of<::sigslot::detail::observer_type,
+                                               std::remove_pointer_t<T>>::value;
 
 } // namespace trait
 
@@ -687,30 +692,37 @@ private:
 };
 
 /**
- * Observer for automatic slot lifetime tracking. Derive classes which
- * act as slot from this and they will automatically disconnect from
- * signals when the instance is deleted.
+ * Observer is a base class for intrusive lifetime tracking of objects.
+ *
+ * This is an alternative to trackable pointers, such as std::shared_ptr,
+ * and manual connection management by keeping connection objects in scope.
+ * Deriving from this class allows automatic disconnection of all the slots
+ * connected to any signal when an instance is destroyed.
  */
 template <typename Lockable>
-struct observer_base {
-
+struct observer_base : private detail::observer_type {
     virtual ~observer_base() = default;
 
 protected:
-
-    void disconnect_all() noexcept {
+    /**
+     * Disconnect all signals connected to this object.
+     *
+     * To avoid invocation of slots on a semi-destructed instance, which may happen
+     * in multi-threaded contexts, derived classes should call this method in their
+     * destructor. This will ensure proper disconnection prior to the destruction.
+     */
+    void disconnect_all() {
         std::unique_lock<Lockable> _{m_mutex};
         m_connections.clear();
     }
 
 private:
-
     template <typename, typename ...>
     friend class signal_base;
 
-    void add_connection(connection &&conn) {
+    void add_connection(connection conn) {
         std::unique_lock<Lockable> _{m_mutex};
-        m_connections.emplace_back(conn);
+        m_connections.emplace_back(std::move(conn));
     }
 
     Lockable m_mutex;
@@ -726,6 +738,7 @@ using observer_st = observer_base<detail::null_mutex>;
  * Specialization of observer_base to be used in multi-threaded contexts.
  */
 using observer = observer_base<std::mutex>;
+
 
 namespace detail {
 
@@ -1225,16 +1238,15 @@ public:
      * @return a connection object that can be used to interact with the slot
      */
     template <typename Pmf, typename Ptr>
-    std::enable_if_t<
-    trait::is_callable_v<arg_list, Pmf, Ptr> &&
-    trait::is_observer_v<Lockable, std::remove_pointer_t<Ptr>> &&
-    !trait::is_weak_ptr_compatible_v<Ptr>, void>
+    std::enable_if_t<trait::is_callable_v<arg_list, Pmf, Ptr> &&
+                     trait::is_observer_v<Ptr>, connection>
     connect(Pmf && pmf, Ptr && ptr, group_id gid = 0) {
         using slot_t = detail::slot_pmf<Pmf, Ptr, T...>;
         auto s = make_slot<slot_t>(std::forward<Pmf>(pmf), std::forward<Ptr>(ptr), gid);
         connection conn(s);
         add_slot(std::move(s));
-        ptr->add_connection(std::move(conn));
+        ptr->add_connection(conn);
+        return conn;
     }
 
     /**
@@ -1246,11 +1258,9 @@ public:
      * @return a connection object that can be used to interact with the slot
      */
     template <typename Pmf, typename Ptr>
-    std::enable_if_t<
-    trait::is_callable_v<arg_list, Pmf, Ptr> &&
-    !trait::is_observer_v<std::mutex, std::remove_pointer_t<Ptr>> &&
-    !trait::is_observer_v<detail::null_mutex, std::remove_pointer_t<Ptr>> &&
-    !trait::is_weak_ptr_compatible_v<Ptr>, connection>
+    std::enable_if_t<trait::is_callable_v<arg_list, Pmf, Ptr> &&
+                     !trait::is_observer_v<Ptr> &&
+                     !trait::is_weak_ptr_compatible_v<Ptr>, connection>
     connect(Pmf && pmf, Ptr && ptr, group_id gid = 0) {
         using slot_t = detail::slot_pmf<Pmf, Ptr, T...>;
         auto s = make_slot<slot_t>(std::forward<Pmf>(pmf), std::forward<Ptr>(ptr), gid);

--- a/test/observer.cpp
+++ b/test/observer.cpp
@@ -6,26 +6,47 @@
 
 struct s : ::sigslot::observer
 {
-    void f1 (int& i) { ++i; }
+    ~s() override
+    {
+        this->disconnect_all();
+    }
+
+    void f1 (int &i)
+    {
+        ++i;
+    }
 };
 
-struct s2
+struct s_st : ::sigslot::observer_st
 {
-    void f1 (int& i) { ++i; }
+    void f1 (int &i)
+    {
+        ++i;
+    }
 };
 
-void test_observer() {
-    sigslot::signal<int&> sig;
+struct s_plain
+{
+    void f1 (int &i)
+    {
+        ++i;
+    }
+};
+
+template <typename T, template <typename...> class SIG_T>
+void test_observer()
+{
+    SIG_T<int &> sig;
 
     // Automatic disconnect via observer inheritance
     {
-        s p;
-        sig.connect(&s::f1, &p);
+        T p;
+        sig.connect(&T::f1, &p);
         assert(sig.slot_count() == 1);
 
         {
-            s p;
-            sig.connect(&s::f1, &p);
+            T p;
+            sig.connect(&T::f1, &p);
             assert(sig.slot_count() == 2);
         }
 
@@ -36,26 +57,28 @@ void test_observer() {
 
     // No automatic disconnect
     {
-        s2 p;
-        sig.connect(&s2::f1, &p);
+        s_plain p;
+        sig.connect(&s_plain::f1, &p);
         assert(sig.slot_count() == 1);
     }
 
     assert(sig.slot_count() == 1);
 }
 
-void test_observer_signals() {
+template <typename T, template <typename...> class SIG_T>
+void test_observer_signals()
+{
     int sum = 0;
-    sigslot::signal<int&> sig;
+    SIG_T<int &> sig;
 
     {
-        s p;
-        sig.connect(&s::f1, &p);
+        T p;
+        sig.connect(&T::f1, &p);
         sig(sum);
         assert(sum == 1);
         {
-            s p;
-            sig.connect(&s::f1, &p);
+            T p;
+            sig.connect(&T::f1, &p);
             sig(sum);
             assert(sum == 3);
         }
@@ -66,15 +89,18 @@ void test_observer_signals() {
     assert(sum == 4);
 }
 
-void test_observer_signals_list() {
+template <typename T, template <typename...> class SIG_T>
+void test_observer_signals_list()
+{
     int sum = 0;
-    sigslot::signal<int&> sig;
+    SIG_T<int &> sig;
 
     {
-        std::list<s> l;
-        for (auto i = 0; i < 10; ++i) {
+        std::list<T> l;
+        for (auto i = 0; i < 10; ++i)
+        {
             l.emplace_back();
-            sig.connect(&s::f1, &l.back());
+            sig.connect(&T::f1, &l.back());
         }
         assert(sig.slot_count() == 10);
         sig(sum);
@@ -85,29 +111,37 @@ void test_observer_signals_list() {
     assert(sum == 10);
 }
 
-void test_observer_signals_vector() {
+template <typename T, template <typename...> class SIG_T>
+void test_observer_signals_vector()
+{
     int sum = 0;
-    sigslot::signal<int&> sig;
+    SIG_T<int &> sig;
 
     {
-        std::vector<std::unique_ptr<s>> v;
-        for (auto i = 0; i < 10; ++i) {
-            v.emplace_back(new s);
-            sig.connect(&s::f1, v.back().get());
+        std::vector<std::unique_ptr<T>> v;
+        for (auto i = 0; i < 10; ++i)
+        {
+            v.emplace_back(new T);
+            sig.connect(&T::f1, v.back().get());
         }
         assert(sig.slot_count() == 10);
         sig(sum);
         assert(sum == 10);
     }
-        assert(sig.slot_count() == 0);
+    assert(sig.slot_count() == 0);
     sig(sum);
     assert(sum == 10);
 }
 
-int main() {
-    test_observer();
-    test_observer_signals();
-    test_observer_signals_list();
-    test_observer_signals_vector();
+int main()
+{
+    test_observer<s, ::sigslot::signal>();
+    test_observer<s_st, ::sigslot::signal_st>();
+    test_observer_signals<s, ::sigslot::signal>();
+    test_observer_signals<s_st, ::sigslot::signal_st>();
+    test_observer_signals_list<s, ::sigslot::signal>();
+    test_observer_signals_list<s_st, ::sigslot::signal_st>();
+    test_observer_signals_vector<s, ::sigslot::signal>();
+    test_observer_signals_vector<s_st, ::sigslot::signal_st>();
     return 0;
 }

--- a/test/observer.cpp
+++ b/test/observer.cpp
@@ -1,0 +1,113 @@
+#include "test-common.h"
+#include <sigslot/signal.hpp>
+#include <cassert>
+#include <list>
+#include <vector>
+
+struct s : ::sigslot::observer
+{
+    void f1 (int& i) { ++i; }
+};
+
+struct s2
+{
+    void f1 (int& i) { ++i; }
+};
+
+void test_observer() {
+    sigslot::signal<int&> sig;
+
+    // Automatic disconnect via observer inheritance
+    {
+        s p;
+        sig.connect(&s::f1, &p);
+        assert(sig.slot_count() == 1);
+
+        {
+            s p;
+            sig.connect(&s::f1, &p);
+            assert(sig.slot_count() == 2);
+        }
+
+        assert(sig.slot_count() == 1);
+    }
+
+    assert(sig.slot_count() == 0);
+
+    // No automatic disconnect
+    {
+        s2 p;
+        sig.connect(&s2::f1, &p);
+        assert(sig.slot_count() == 1);
+    }
+
+    assert(sig.slot_count() == 1);
+}
+
+void test_observer_signals() {
+    int sum = 0;
+    sigslot::signal<int&> sig;
+
+    {
+        s p;
+        sig.connect(&s::f1, &p);
+        sig(sum);
+        assert(sum == 1);
+        {
+            s p;
+            sig.connect(&s::f1, &p);
+            sig(sum);
+            assert(sum == 3);
+        }
+        sig(sum);
+        assert(sum == 4);
+    }
+    sig(sum);
+    assert(sum == 4);
+}
+
+void test_observer_signals_list() {
+    int sum = 0;
+    sigslot::signal<int&> sig;
+
+    {
+        std::list<s> l;
+        for (auto i = 0; i < 10; ++i) {
+            l.emplace_back();
+            sig.connect(&s::f1, &l.back());
+        }
+        assert(sig.slot_count() == 10);
+        sig(sum);
+        assert(sum == 10);
+    }
+    assert(sig.slot_count() == 0);
+    sig(sum);
+    assert(sum == 10);
+}
+
+void test_observer_signals_vector() {
+    int sum = 0;
+    sigslot::signal<int&> sig;
+
+    {
+        std::vector<std::unique_ptr<s>> v;
+        for (auto i = 0; i < 10; ++i) {
+            v.emplace_back(new s);
+            sig.connect(&s::f1, v.back().get());
+        }
+        assert(sig.slot_count() == 10);
+        sig(sum);
+        assert(sum == 10);
+    }
+        assert(sig.slot_count() == 0);
+    sig(sum);
+    assert(sum == 10);
+}
+
+int main() {
+    test_observer();
+    test_observer_signals();
+    test_observer_signals_list();
+    test_observer_signals_vector();
+    return 0;
+}


### PR DESCRIPTION
Added way to handled automatic slot lifecycle with inheritance. Check tests/observer.cpp for usage.