### PR TITLE
FetchContent compatible

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -49,7 +49,7 @@ jobs:
         shell: bash
       -
         name: 🔨 sigslot-examples
-        run: cmake --build build --target sigslot-examples --config "${{ matrix.build_type }}" -j $(nproc)
+        run: cmake --build build --target sigslot-examples --config "${{ matrix.build_type }}"
       -
         name: 🔨 sigslot-tests
-        run: cmake --build build --target sigslot-tests --config "${{ matrix.build_type }}" -j $(nproc)
+        run: cmake --build build --target sigslot-tests --config "${{ matrix.build_type }}"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -53,6 +53,3 @@ jobs:
       -
         name: 🔨 sigslot-tests
         run: cmake --build build --target sigslot-tests --config "${{ matrix.build_type }}" -j $(nproc)
-      -
-        name: ✅ Unit Tests
-        run: cd build && ctest --build-config "${{ matrix.build_type }}" --progress --verbose

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -49,10 +49,10 @@ jobs:
         shell: bash
       -
         name: 🔨 sigslot-examples
-        run: cmake --build build --target examples --config "${{ matrix.build_type }}" -j $(nproc)
+        run: cmake --build build --target sigslot-examples --config "${{ matrix.build_type }}" -j $(nproc)
       -
         name: 🔨 sigslot-tests
-        run: cmake --build build --target tests --config "${{ matrix.build_type }}" -j $(nproc)
+        run: cmake --build build --target sigslot-tests --config "${{ matrix.build_type }}" -j $(nproc)
       -
         name: ✅ Unit Tests
         run: cd build && ctest --build-config "${{ matrix.build_type }}" --progress --verbose

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,58 @@
+name: ✅ Unit Tests
+
+on:
+  push:
+    branches:
+      - master
+      - main
+      - ci
+
+  pull_request:
+    branches:
+      - master
+      - main
+
+jobs:
+  Test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        qt-version: ['5.15.2']
+        build_type: ['Debug', 'Release']
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+      -
+        name: 📦 Cache Qt
+        id: cache-qt
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/Qt-${{ runner.os }}-${{ matrix.qt-version }}
+          key: ${{ runner.os }}-QtCache-${{ matrix.qt-version }}
+      -
+        name: ⬇ Install Qt
+        uses: jurplel/install-qt-action@v2
+        with:
+          version: ${{ matrix.qt-version }}
+          dir: ${{ github.workspace }}/Qt-${{ runner.os }}-${{ matrix.qt-version }}
+          cached: ${{ steps.cache-qt.outputs.cache-hit }}
+      -
+        name: 🔧 sigslot
+        run: |
+          cmake -E make_directory build
+          cmake                                              \
+            -DCMAKE_BUILD_TYPE="${{ matrix.build_type }}"    \
+            -DSIGSLOT_COMPILE_TESTS=ON                       \
+            -DSIGSLOT_COMPILE_EXAMPLES=ON                    \
+            -B build -S .
+        shell: bash
+      -
+        name: 🔨 sigslot-examples
+        run: cmake --build build --target examples --config "${{ matrix.build_type }}" -j $(nproc)
+      -
+        name: 🔨 sigslot-tests
+        run: cmake --build build --target tests --config "${{ matrix.build_type }}" -j $(nproc)
+      -
+        name: ✅ Unit Tests
+        run: cd build && ctest --build-config "${{ matrix.build_type }}" --progress --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Allow in source build
+[Bb]uild*/
+# Ignore qt creator generated CMakeLists.txt.users
+*.users
+# Ignore CLion project files
+*.idea
+# Ignore CLion default generated build folder
+cmake-build*/
+# For macOs users
+.DS_Store
+# Ignore sublime merge file that can be created on merge fail
+Sublimerge*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,17 @@ cmake_minimum_required(VERSION 3.5)
 
 project(pal_sigslot VERSION 1.2.0 LANGUAGES CXX)
 
+### main project
+set(SIGSLOT_MAIN_PROJECT OFF)
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  set(SIGSLOT_MAIN_PROJECT ON)
+endif()
+
 include(cmake/SigslotUtils.cmake)
 
 ### options
-option(SIGSLOT_COMPILE_EXAMPLES "Compile optional exemples" ON)
-option(SIGSLOT_COMPILE_TESTS "Compile tests" ON)
+option(SIGSLOT_COMPILE_EXAMPLES "Compile optional exemples" ${SIGSLOT_MAIN_PROJECT})
+option(SIGSLOT_COMPILE_TESTS "Compile tests" ${SIGSLOT_MAIN_PROJECT})
 option(SIGSLOT_REDUCE_COMPILE_TIME "Attempt at reducing code size and compilation time" OFF)
 
 find_package(Threads REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 include(cmake/SigslotUtils.cmake)
 
 ### options
-option(SIGSLOT_COMPILE_EXAMPLES "Compile optional exemples" ${SIGSLOT_MAIN_PROJECT})
+option(SIGSLOT_COMPILE_EXAMPLES "Compile optional examples" ${SIGSLOT_MAIN_PROJECT})
 option(SIGSLOT_COMPILE_TESTS "Compile tests" ${SIGSLOT_MAIN_PROJECT})
 option(SIGSLOT_REDUCE_COMPILE_TIME "Attempt at reducing code size and compilation time" OFF)
 option(SIGSLOT_ENABLE_INSTALL "Create install target" ${SIGSLOT_MAIN_PROJECT})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 project(pal_sigslot VERSION 1.2.0 LANGUAGES CXX)
 
-include(SigslotUtils)
+include(cmake/SigslotUtils.cmake)
 
 ### options
 option(SIGSLOT_COMPILE_EXAMPLES "Compile optional exemples" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,5 +91,6 @@ if(SIGSLOT_COMPILE_EXAMPLES)
 endif()
 
 if(SIGSLOT_COMPILE_TESTS)
+    enable_testing()
     add_subdirectory(test)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ include(cmake/SigslotUtils.cmake)
 option(SIGSLOT_COMPILE_EXAMPLES "Compile optional exemples" ${SIGSLOT_MAIN_PROJECT})
 option(SIGSLOT_COMPILE_TESTS "Compile tests" ${SIGSLOT_MAIN_PROJECT})
 option(SIGSLOT_REDUCE_COMPILE_TIME "Attempt at reducing code size and compilation time" OFF)
+option(SIGSLOT_ENABLE_INSTALL "Create install target" ${SIGSLOT_MAIN_PROJECT})
 
 find_package(Threads REQUIRED)
 
@@ -36,54 +37,56 @@ target_link_options(sigslot INTERFACE
 target_link_libraries(sigslot INTERFACE Threads::Threads)
 set_target_properties(sigslot PROPERTIES EXPORT_NAME Sigslot)
 
-#installation
-include(GNUInstallDirs)
-include(CMakePackageConfigHelpers)
+if(SIGSLOT_ENABLE_INSTALL)
+    #installation
+    include(GNUInstallDirs)
+    include(CMakePackageConfigHelpers)
 
-configure_package_config_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/PalSigslotConfig.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/PalSigslotConfig.cmake
-    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/PalSigslot"
-)
+    configure_package_config_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/PalSigslotConfig.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/PalSigslotConfig.cmake
+        INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/PalSigslot"
+    )
 
-write_basic_package_version_file(
-    ${CMAKE_CURRENT_BINARY_DIR}/PalSigslotConfigVersion.cmake
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY SameMajorVersion
-)
+    write_basic_package_version_file(
+        ${CMAKE_CURRENT_BINARY_DIR}/PalSigslotConfigVersion.cmake
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY SameMajorVersion
+    )
 
-install(
-    TARGETS sigslot
-    EXPORT PalSigslotTargets
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}
-)
-install(
-    DIRECTORY include/
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
-install(
-    EXPORT PalSigslotTargets
-    FILE PalSigslotTargets.cmake
-    NAMESPACE Pal::
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/PalSigslot"
-)
-install(
-    FILES ${CMAKE_CURRENT_BINARY_DIR}/PalSigslotConfig.cmake
-          ${CMAKE_CURRENT_BINARY_DIR}/PalSigslotConfigVersion.cmake
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/PalSigslot"
-)
-export(TARGETS sigslot
-    NAMESPACE Pal::
-    FILE ${CMAKE_CURRENT_BINARY_DIR}/PalSigslotTargets.cmake
-)
+    install(
+        TARGETS sigslot
+        EXPORT PalSigslotTargets
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    )
+    install(
+        DIRECTORY include/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
+    install(
+        EXPORT PalSigslotTargets
+        FILE PalSigslotTargets.cmake
+        NAMESPACE Pal::
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/PalSigslot"
+    )
+    install(
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/PalSigslotConfig.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/PalSigslotConfigVersion.cmake
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/PalSigslot"
+    )
+    export(TARGETS sigslot
+        NAMESPACE Pal::
+        FILE ${CMAKE_CURRENT_BINARY_DIR}/PalSigslotTargets.cmake
+    )
 
-# Install the Config and ConfigVersion files
-install(
-    FILES ${version_file}
-          ${config_file}
-    DESTINATION ${cmake_dir}
-    COMPONENT ${projectname_target}Export
-)
+    # Install the Config and ConfigVersion files
+    install(
+        FILES ${version_file}
+              ${config_file}
+        DESTINATION ${cmake_dir}
+        COMPONENT ${projectname_target}Export
+    )
+endif()
 
 # dependencies for examples and tests
 if(SIGSLOT_COMPILE_TESTS OR SIGSLOT_COMPILE_EXAMPLES)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -13,6 +13,7 @@ file(GLOB_RECURSE UNIT_TESTS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.cpp")
 foreach(ex IN LISTS UNIT_TESTS)
     string(REPLACE ".cpp" "" target ${ex})
     string(REGEX REPLACE "/" "." target ${target})
+    set(target sigslot-example-${target})
 
     if (target MATCHES "boost")
         if (TARGET Boost::system)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,11 +1,11 @@
-add_custom_target(examples COMMENT "Build all the examples.")
+add_custom_target(sigslot-examples COMMENT "Build all the examples.")
 
 macro(pal_create_example target ut)
     add_executable(${target} EXCLUDE_FROM_ALL "${ut}")
     target_link_libraries(${target} PRIVATE Pal::Sigslot)
     target_compile_options(${target} PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/bigobj>)
     target_compile_definitions(${target} PRIVATE $<$<CXX_COMPILER_ID:MSVC>:_SCL_SECURE_NO_WARNINGS>)
-    add_dependencies(examples ${target})
+    add_dependencies(sigslot-examples ${target})
     sigslot_set_properties(${target} PRIVATE)
 endmacro()
 

--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,24 @@ cmake --build . --target examples
 cmake --build . --target tests
 ```
 
+### CMake FetchContent
+
+`Pal::Sigslot` can also be integrated using the [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html) method.
+
+```cmake
+include(FetchContent)
+
+FetchContent_Declare(
+  sigslot
+  GIT_REPOSITORY https://github.com/palacaze/sigslot
+  GIT_TAG        19a6f0f5ea11fc121fe67f81fd5e491f2d7a4637 # v1.2.0
+)
+FetchContent_MakeAvailable(sigslot)
+
+add_executable(MyExe main.cpp)
+target_link_libraries(MyExe PRIVATE Pal::Sigslot)
+```
+
 ## Documentation
 
 Sigslot implements the signal-slot construct popular in UI frameworks, making it

--- a/readme.md
+++ b/readme.md
@@ -59,10 +59,10 @@ cmake .. -DSIGSLOT_REDUCE_COMPILE_TIME=ON -DCMAKE_INSTALL_PREFIX=~/local
 cmake --build . --target install
 
 # If you want to compile examples:
-cmake --build . --target examples
+cmake --build . --target sigslot-examples
 
 # And compile/execute unit tests:
-cmake --build . --target tests
+cmake --build . --target sigslot-tests
 ```
 
 ### CMake FetchContent

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-enable_testing()
-
 add_custom_target(tests
     COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
     COMMENT "Build and run all the unit tests.")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,11 +1,11 @@
-add_custom_target(tests
+add_custom_target(sigslot-tests
     COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
     COMMENT "Build and run all the unit tests.")
 
 macro(pal_create_test target ut)
     add_executable(${target} EXCLUDE_FROM_ALL "${ut}")
     add_test(${target} ${target})
-    add_dependencies(tests ${target})
+    add_dependencies(sigslot-tests ${target})
     sigslot_set_properties(${target} PRIVATE)
     target_link_libraries(${target} PRIVATE Pal::Sigslot)
     target_compile_definitions(${target} PRIVATE $<$<CXX_COMPILER_ID:MSVC>:_SCL_SECURE_NO_WARNINGS>)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,7 @@ file(GLOB_RECURSE UNIT_TESTS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.cpp")
 foreach(ut IN LISTS UNIT_TESTS)
     string(REPLACE ".cpp" "" target ${ut})
     string(REGEX REPLACE "/" "." target ${target})
+    set(target sigslot-test-${target})
 
     if (target MATCHES "boost")
         if (TARGET Boost::system)


### PR DESCRIPTION
I'm using `sigslot` with `FetchContent`.
- I don't need install
- tests & examples should be disabled by default
- tests & examples targets should be namespace to avoid conflict with any other project, if I need to enable examples/tests somehow

No original behavior got changed if you are only using this repo to install, except the namespacing of examples/tests targets.

This PR introduce:
*  add a minimal `.gitignore` to allow in source build
* github CI for windows/linux/mac
* `SIGSLOT_MAIN_PROJECT` cmake variable to ON when sigslot is the main project (current behavior)
* `SIGSLOT_MAIN_PROJECT` cmake variable to OFF when sigslot is included with `add_subdirectory`
* `SIGSLOT_ENABLE_INSTALL` to make install step optionnal. (Enable when main project)
* `SIGSLOT_COMPILE_EXAMPLES` enabled only if main project
* `SIGSLOT_COMPILE_TESTS` enabled only if main project
* All tests & examples targets are namespaced with `sigslot-` prefix
* Don't alter `CMAKE_MODULE_PATH` anymore by including `SigslotUtils` using relative path.
* Enable CTest in main build folder when tests are enabled.

Issue reference https://github.com/palacaze/sigslot/issues/24