### PR TITLE
Avoid warnings about undefined __GNUC__ with non-gcc compilers

### DIFF
--- a/include/sigslot/signal.hpp
+++ b/include/sigslot/signal.hpp
@@ -7,7 +7,7 @@
 #include <thread>
 #include <vector>
 
-#if defined __clang__ || (__GNUC__ > 5)
+#if defined __clang__ || (defined __GNUC__ && (__GNUC__ > 5))
 #define SIGSLOT_MAY_ALIAS __attribute__((__may_alias__))
 #else
 #define SIGSLOT_MAY_ALIAS


### PR DESCRIPTION
Check that __GNUC__ is defined before testing its value to avoid the
equivalent of gcc -Wundef with other compilers, notably MSVC.

---

No real changes, but just a very minor fix to avoid this MSVC warning (which is disabled by default but that I enable for all my code, as it's quite useful fore detecting typos etc).