### PR TITLE
Ignore exceptions thrown from multiple signals

### DIFF
--- a/include/sigslot/signal.hpp
+++ b/include/sigslot/signal.hpp
@@ -1200,7 +1200,9 @@ public:
 
         for (const auto &group : detail::cow_read(ref)) {
             for (const auto &s : group.slts) {
-                s->operator()(a...);
+                try {
+                    s->operator()(a...);
+                catch (...) {}
             }
         }
     }


### PR DESCRIPTION
Since signals do not allow for returning values from calls, it logically follows that we should not let exceptions bubble up. If we do allow exceptions to bubble up, we stop execution of every slot that follows, as well as potentially exposing the emitting code to an exception it is unprepared to handle.