### PR TITLE
Add exception handling to signal emission

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(pal_sigslot VERSION 1.2.2 LANGUAGES CXX)
+project(pal_sigslot VERSION 2.0.0 LANGUAGES CXX)
 
 ### main project
 set(SIGSLOT_MAIN_PROJECT OFF)

--- a/test/signal-exceptions.cpp
+++ b/test/signal-exceptions.cpp
@@ -1,0 +1,79 @@
+#include <cassert>
+#include <sigslot/signal.hpp>
+
+class TestingClass final {
+public:
+    TestingClass(bool should_throw, std::atomic_int &cumulative) : m_should_throw(should_throw),
+                                                                   m_cumulative(cumulative) {
+    }
+
+    void function(int x) const {
+        m_cumulative += x;
+        if (m_should_throw) {
+            throw std::runtime_error("Throwing variant");
+        }
+    }
+
+private:
+    bool m_should_throw;
+    std::atomic_int &m_cumulative;
+};
+
+void test_plain_exceptions() {
+    constexpr int k_emitted_value{3};
+
+    std::atomic_int cumulative{0};
+
+    TestingClass t1{true, cumulative};
+    TestingClass t2{false, cumulative};
+    TestingClass t3{true, cumulative};
+
+    sigslot::signal<int> signal;
+
+    signal.connect(&TestingClass::function, &t1, 1);
+    signal.connect(&TestingClass::function, &t2, 2);
+    signal.connect(&TestingClass::function, &t3, 3);
+
+    std::vector<std::exception_ptr> exceptions;
+    try {
+        exceptions = signal(k_emitted_value);
+    } catch (...) {
+        assert(!static_cast<bool>("Should not get exceptions outside signals!"));
+    }
+
+    assert(exceptions.size() == 2);
+    assert(cumulative == (signal.slot_count() * k_emitted_value));
+}
+
+void test_connected_signal_exceptions() {
+    constexpr int k_emitted_value{3};
+
+    std::atomic_int cumulative{0};
+    TestingClass tc{true, cumulative};
+
+    // Create two signals
+    sigslot::signal<int> signal1;
+    sigslot::signal<int> signal2;
+
+    // Connect the second signal with the first one
+    sigslot::connect(signal1, signal2);
+
+    // Connect the TestingClass function method to the second signal
+    signal2.connect(&TestingClass::function, &tc);
+
+    std::vector<std::exception_ptr> exceptions;
+    // Emit the first signal
+    try {
+        exceptions = signal1(k_emitted_value);
+    } catch (...) {
+        assert(!static_cast<bool>("Should not get exceptions outside signals!"));
+    }
+
+    assert(exceptions.size() == 1);
+    assert(cumulative == k_emitted_value);
+}
+
+int main() {
+    test_plain_exceptions();
+    test_connected_signal_exceptions();
+}


### PR DESCRIPTION
The `operator()` method inside `signal.hpp` and new test cases have been added to handle the functionality of exceptions when signals are emitted. Now the function returns a vector of `std::exception_ptr`s for any exceptions that occurred during the signal emission.

Since this is an ABI breaking change, the version has been updated to 2.0.0.

I am resurrecting the concept of #30, and updating it so that users can get the exceptions that were thrown, instead of completely swallowing them. This is meant to help my company replace an old eventing system with sigslot, which we already use. This system currently uses a signal from before we could use packages, and so in order to upgrade completely to sigslot we have to maintain behavior. We have decided that exceptions must be thrown from those connected exceptions, and the current system accumulates exceptions to call all connected slots. While this could also be solved by creating wrapper functions that swallow exceptions, this gives an effective mechanism for all users to maintain some more information from their signals, while not throwing potentially "random" or unexpected exceptions from consumers.